### PR TITLE
Removing unsupported stuff

### DIFF
--- a/src/devlib/devlib.cc
+++ b/src/devlib/devlib.cc
@@ -8,7 +8,6 @@
 #include "piFace.h"
 #include "piGlow.h"
 #include "piNes.h"
-#include "tcs34725.h"
 
 IMPLEMENT_EXPORT_INIT(devlib) {
   INIT(ds1302);
@@ -19,5 +18,4 @@ IMPLEMENT_EXPORT_INIT(devlib) {
   INIT(piFace);
   INIT(piGlow);
   INIT(piNes);
-  INIT(tcs34725);
 }


### PR DESCRIPTION
WiringOP doesn't have these files -> That causes errors while using node-wiring-op, if lines which I showed before are deleted.
