### PR TITLE
Removing unsupported stuff

### DIFF
--- a/src/extensions/extensions.cc
+++ b/src/extensions/extensions.cc
@@ -1,6 +1,5 @@
 #include "extensions.h"
 
-#include "dac7678.h"
 #include "drcSerial.h"
 #include "max5322.h"
 #include "max31855.h"
@@ -17,10 +16,8 @@
 #include "pcf8591.h"
 #include "sn3218.h"
 #include "sr595.h"
-#include "pca9685.h"
 
 IMPLEMENT_EXPORT_INIT(extensions) {
-  INIT(dac7678);
   INIT(drcSerial);
   INIT(max5322);
   INIT(max31855);
@@ -36,5 +33,4 @@ IMPLEMENT_EXPORT_INIT(extensions) {
   INIT(pcf8574);
   INIT(pcf8591);
   INIT(sr595);
-  INIT(pca9685);
 }


### PR DESCRIPTION
WiringOP doesn't have these files -> That causes errors while using node-wiring-op, if lines which I showed before are deleted.
